### PR TITLE
chore: add root .npmrc for supply chain security baseline

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,21 @@
+# ===== Supply chain security =====
+# Pin to official npm registry (防钓鱼源)
+registry=https://registry.npmjs.org/
+
+# ===== Lockfile integrity =====
+# Pin exact versions on npm install (防 minor/patch 漂移)
+save-exact=true
+# Always maintain package-lock (防 lockfile 被删)
+package-lock=true
+
+# ===== Environment consistency =====
+# Enforce engines field (防 Node/npm 版本不匹配)
+engine-strict=true
+
+# ===== Audit strategy =====
+# Auto-run audit on install
+audit=true
+# Fail install on high+ severity
+audit-level=high
+# Silence funding output (noise reduction)
+fund=false


### PR DESCRIPTION
## Summary

- 新增根 `.npmrc`（21 行，含注释与空行）
- Pin registry 到官方 npm、启用 audit（`audit-level=high`）、锁 lockfile 完整性（`package-lock=true` + `save-exact=true`）、`engine-strict=true`
- 单文件原子提交，未触碰 `package.json`、`bun.lock`、`bunfig.toml`、CI 或 hooks

## Test plan

- [ ] CI 通过
- [ ] `git diff main --stat` 仅显示 `.npmrc | 21 +++`
- [ ] `.npmrc` 与 issue STU-1541 模板逐字一致

Refs: STU-1541